### PR TITLE
Fix game logic bugs in Reboot tech tree

### DIFF
--- a/.cursor/skills/reboot-game/SKILL.md
+++ b/.cursor/skills/reboot-game/SKILL.md
@@ -7,7 +7,7 @@ description: Architecture and conventions for the Reboot civilization strategy g
 
 ## Overview
 
-Reboot is a browser-based civilization-rebuilding strategy game. Players progress through 6 eras (Survival to Renaissance) by making narrative decisions about 36 technologies. Vanilla TypeScript, no framework, bundled with Bun.
+Reboot is a browser-based civilization-rebuilding strategy game. Players progress through 6 eras (Survival to Renaissance) by making narrative decisions about 37 technologies. Vanilla TypeScript, no framework, bundled with Bun.
 
 Inspired by "The Knowledge" by Lewis Dartnell. All game content is original.
 
@@ -46,7 +46,7 @@ CI builds with `oven-sh/setup-bun@v2` in `.github/workflows/deploy.yml`.
 ## Game Mechanics
 
 ### Tech Tree
-- 36 techs across 6 eras (0-5), 7 categories (food, energy, materials, medicine, comm, chemical, science)
+- 37 techs across 6 eras (0-5), 7 categories (food, energy, materials, medicine, comm, chemical, science)
 - Each tech has: scenario (narrative), 2 decisions (choices with correct answer), prereqs, x/y position
 - Era advancement gated by total resource points (not tech count)
 - Wrong answers: accept the choice, teach correct answer via narrative, always advance. No retries.

--- a/reboot/src/quiz.ts
+++ b/reboot/src/quiz.ts
@@ -362,7 +362,8 @@ export class QuizPanel {
         ? Math.max(1, Math.floor(this.state.getPopGainPerUnlock() / 2))
         : 1;
 
-    const resInfo = node && correct >= 1 ? QuizPanel.CATEGORY_RESOURCE_LABELS[node.category] : null;
+    const atMax = node && correct >= 1 && this.state.isResourceAtMax(node.category);
+    const resInfo = node && correct >= 1 && !atMax ? QuizPanel.CATEGORY_RESOURCE_LABELS[node.category] : null;
     const resLine = resInfo ? `\n${resInfo.icon} ${resInfo.name} +1: ${resInfo.effect(this.state)}` : "";
     const noResLine = correct === 0 ? "\nNo resource gained." : "";
 

--- a/reboot/src/renderer.ts
+++ b/reboot/src/renderer.ts
@@ -345,10 +345,11 @@ export class Renderer {
     const reveals = this.state.getCommsReveals();
     if (reveals <= 0 || this.state.browseMode) return new Set();
     const scouted = new Set<TechId>();
-    const nextEra = this.state.highestEra + 1;
-    const candidates = TECH_TREE.filter(n => n.era === nextEra && this.state.getNodeState(n.id) === "locked");
-    for (let i = 0; i < Math.min(reveals, candidates.length); i++) {
-      scouted.add(candidates[i].id);
+    for (let era = 1; era <= 5 && scouted.size < reveals; era++) {
+      const candidates = TECH_TREE.filter(n => n.era === era && this.state.getNodeState(n.id) === "locked");
+      for (let i = 0; i < candidates.length && scouted.size < reveals; i++) {
+        scouted.add(candidates[i].id);
+      }
     }
     return scouted;
   }

--- a/reboot/src/state.ts
+++ b/reboot/src/state.ts
@@ -100,6 +100,7 @@ export class GameState {
   private recalcResources(): void {
     const r = emptyResources();
     for (const id of this.unlocked) {
+      if (this.techResults[id] === 0) continue;
       const node = TECH_TREE.find(n => n.id === id);
       if (!node) continue;
       const res = CATEGORY_TO_RESOURCE[node.category];
@@ -155,6 +156,11 @@ export class GameState {
 
   getCommsReveals(): number {
     return this.resources.comms;
+  }
+
+  isResourceAtMax(category: Category): boolean {
+    const res = CATEGORY_TO_RESOURCE[category];
+    return this.resources[res] >= RESOURCE_MAX[res];
   }
 
   incrementStreak(): void {
@@ -273,14 +279,11 @@ export class GameState {
     }
     this.wrongAnswers = (this.wrongAnswers ?? 0) + (2 - correct);
 
-    if (correct >= 1) {
-      this.recalcResources();
-    }
-
     const fullPop = this.getPopGainPerUnlock();
     const popGain = correct === 2 ? fullPop : correct === 1 ? Math.max(1, Math.floor(fullPop / 2)) : 1;
+
+    this.recalcResources();
     this.population = Math.min(this.population + popGain, this.getPopCap());
-    this.prevTierName = this.getPopTier().name;
 
     this.save();
     this.notify();


### PR DESCRIPTION
- Fix unreachable "AGAINST ALL ODDS" milestone: unlock() was overwriting prevTierName before checkMilestones() could detect the crisis-to-stable tier transition
- Fix resource leak for 0-correct techs: recalcResources() now skips techs where the player got both answers wrong, making the "No resource gained" penalty permanent instead of retroactively reversed on the next successful unlock
- Fix pop gain display mismatch: compute popGain before recalcResources() in unlock() so the displayed and actual settler gain match
- Fix misleading "+1 FOOD" message when food resource is already at cap
- Fix scouted nodes disappearing when entering a new era: fill scouted slots with the nearest locked techs across all eras instead of only targeting highestEra + 1
- Update SKILL.md tech count from 36 to 37

Made-with: Cursor