### PR TITLE
Remove feed link from navigation menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,5 +37,4 @@ menu = [
     { url = "https://github.com/ksindi", name = "GitHub" },
     { url = "https://linkedin.com/in/kamilsindi", name = "LinkedIn" },
     { url = "https://x.com/kamilsindi", name = "X" },
-    { url = "/atom.xml", name = "Feed" },
 ]


### PR DESCRIPTION
The Atom feed remains available at /atom.xml via autodiscovery, just no longer listed in the nav.

Made-with: Cursor